### PR TITLE
Updated centroid-test.js - different tests named differently

### DIFF
--- a/test/centroid-test.js
+++ b/test/centroid-test.js
@@ -17,7 +17,7 @@ tape("polygonCentroid(points) returns the expected value for open counterclockwi
   test.end();
 });
 
-tape("polygonCentroid(points) returns the expected value for closed counterclockwise polygons", function(test) {
+tape("polygonCentroid(points) returns the expected values for closed counterclockwise polygons", function(test) {
   test.deepEqual(polygon.polygonCentroid([[0, 0], [1, 0], [1, 1], [0, 1]]), [.5, .5]);
   test.deepEqual(polygon.polygonCentroid([[1, 1], [3, 2], [2, 3]]), [2, 2]);
   test.end();


### PR DESCRIPTION
First and fourth different tests named the same. It may cause problems on non-'tape' test-frameworks That's why it fixed (by adding in fourth case additional 's' letter).

----

Next test named the same:

1)
```js
tape("polygonCentroid(points) returns the expected value for closed counterclockwise polygons", function(test) {
  test.deepEqual(polygon.polygonCentroid([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]), [.5, .5]);
  test.end();
});
```

4)
```js
tape("polygonCentroid(points) returns the expected value for closed counterclockwise polygons", function(test) {
  test.deepEqual(polygon.polygonCentroid([[0, 0], [1, 0], [1, 1], [0, 1]]), [.5, .5]);
  test.deepEqual(polygon.polygonCentroid([[1, 1], [3, 2], [2, 3]]), [2, 2]);
  test.end();
});
```

It may produce warnings/errors on non-`tape` testing-framework, or even on another languages libraries. For example: c++ implementation, covered by `catch2`, warned about it:

![image](https://user-images.githubusercontent.com/20372668/75096415-12699f00-55a8-11ea-8250-3c5afb698080.png)
